### PR TITLE
i18n(ja): translate command descriptions to Japanese

### DIFF
--- a/commands/analyze.md
+++ b/commands/analyze.md
@@ -1,5 +1,5 @@
 ---
-description: 代码库分析，从 Git 历史和代码结构提取编码模式
+description: コードベース分析、Git 履歴とコード構造からコーディングパターンを抽出
 argument-hint: "[--commits N] [--domain name]"
 allowed-tools: Bash, Read, Write, Grep, Glob, TodoWrite
 ---

--- a/commands/build.md
+++ b/commands/build.md
@@ -1,5 +1,5 @@
 ---
-description: 构建项目并检查错误（修复错误见 /cc-best:fix）
+description: プロジェクトをビルドしエラーを検出（修正は /cc-best:fix）
 allowed-tools: Read, Glob, Grep, Bash, Task
 ---
 

--- a/commands/catchup.md
+++ b/commands/catchup.md
@@ -1,5 +1,5 @@
 ---
-description: 快速恢复上下文，了解项目当前状态
+description: コンテキストを素早く復元、プロジェクトの現状を把握
 argument-hint: "[session-id]"
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/commands/cc-ralph.md
+++ b/commands/cc-ralph.md
@@ -1,5 +1,5 @@
 ---
-description: CC-Best Ralph Loop 集成，长时间自主循环
+description: CC-Best Ralph Loop 統合、長時間の自律ループ
 argument-hint: "[task-description]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, WebSearch, WebFetch, Skill, mcp__*
 ---

--- a/commands/checkpoint.md
+++ b/commands/checkpoint.md
@@ -1,5 +1,5 @@
 ---
-description: 检查点管理，保存和恢复进度
+description: チェックポイント管理、進捗の保存と復元
 argument-hint: "[save|restore|list] [--archive]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 ---

--- a/commands/clarify.md
+++ b/commands/clarify.md
@@ -1,5 +1,5 @@
 ---
-description: 需求澄清智能体，解决 REQ 文档中的待澄清项
+description: 要件明確化エージェント、REQ ドキュメントの未確定項目を解消
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite, Task, WebSearch, WebFetch
 ---
 

--- a/commands/cleanup.md
+++ b/commands/cleanup.md
@@ -1,5 +1,5 @@
 ---
-description: 死代码清理和代码整理
+description: デッドコード削除とコード整理
 argument-hint: "[--dry-run|--aggressive]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/codemap.md
+++ b/commands/codemap.md
@@ -1,5 +1,5 @@
 ---
-description: 代码架构文档生成，自动扫描项目结构生成 token 优化的架构图
+description: コードアーキテクチャ文書生成、プロジェクト構造を自動スキャンし token 最適化した構造図を生成
 argument-hint: "[--scope frontend|backend|all] [--update]"
 allowed-tools: Read, Write, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -1,5 +1,5 @@
 ---
-description: Git 提交命令，生成规范的 commit message（另见 /cc-best:git-guide 操作指南）
+description: Git コミットコマンド、規約準拠の commit message を生成（操作ガイドは /cc-best:git-guide）
 allowed-tools: Read, Glob, Grep, Bash
 ---
 

--- a/commands/compact-context.md
+++ b/commands/compact-context.md
@@ -1,5 +1,5 @@
 ---
-description: 上下文压缩，减少 token 消耗
+description: コンテキスト圧縮、token 消費を削減
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite
 ---
 

--- a/commands/confidence-check.md
+++ b/commands/confidence-check.md
@@ -1,5 +1,5 @@
 ---
-description: 置信度检查，评估当前阶段的决策质量和完成度
+description: 確信度チェック、現段階の意思決定品質と完成度を評価
 argument-hint: "[--pre]"
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/commands/context.md
+++ b/commands/context.md
@@ -1,5 +1,5 @@
 ---
-description: 上下文管理，加载项目信息（会话级，另见 /cc-best:memory 管理持久记忆）
+description: コンテキスト管理、プロジェクト情報を読込（セッション単位、永続記憶は /cc-best:memory）
 argument-hint: "[load|save|show]"
 allowed-tools: Read, Write, Edit, Glob, Grep
 ---

--- a/commands/designer.md
+++ b/commands/designer.md
@@ -1,5 +1,5 @@
 ---
-description: UI 设计师智能体，负责界面设计审查和用户体验优化
+description: UI デザイナーエージェント、UI 設計レビューと UX 最適化を担当
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite, Task, WebSearch, WebFetch, Skill, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot
 ---
 

--- a/commands/dev.md
+++ b/commands/dev.md
@@ -1,5 +1,5 @@
 ---
-description: 研发工程师智能体，负责功能编码实现
+description: 開発エンジニアエージェント、機能コードの実装を担当
 argument-hint: "[--bugfix]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, Skill, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_console_messages, mcp__plugin_playwright_playwright__browser_click, mcp__plugin_playwright_playwright__browser_type, mcp__plugin_playwright_playwright__browser_wait_for
 ---

--- a/commands/docs.md
+++ b/commands/docs.md
@@ -1,5 +1,5 @@
 ---
-description: 文档同步，更新项目文档
+description: ドキュメント同期、プロジェクト文書を更新
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---
 

--- a/commands/evolve.md
+++ b/commands/evolve.md
@@ -1,5 +1,5 @@
 ---
-description: 知识演化，将学习内容聚类生成 Skills/Agents/Commands
+description: 知識進化、学習内容をクラスタリングして Skills/Agents/Commands を生成
 argument-hint: "[--execute] [--dry-run] [--domain name]"
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite
 ---

--- a/commands/fix-issue.md
+++ b/commands/fix-issue.md
@@ -1,5 +1,5 @@
 ---
-description: GitHub Issue 端到端修复闭环（分析→修复→测试→提交→关闭）
+description: GitHub Issue のエンドツーエンド修正（分析→修正→テスト→コミット→クローズ）
 argument-hint: "[#issue-number] [--no-close]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite, Task
 ---

--- a/commands/fix.md
+++ b/commands/fix.md
@@ -1,5 +1,5 @@
 ---
-description: 快速修复构建/类型/编译错误，最小化 diff（构建检查见 /cc-best:build）
+description: ビルド/型/コンパイルエラーの即時修正、diff を最小化（ビルド検査は /cc-best:build）
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite, Task
 ---
 

--- a/commands/git-guide.md
+++ b/commands/git-guide.md
@@ -1,5 +1,5 @@
 ---
-description: Git 提交规范和操作指南（参考文档，提交请用 /cc-best:commit）
+description: Git コミット規約と操作ガイド（参考資料、コミットは /cc-best:commit）
 allowed-tools: Read, Glob, Grep, Bash
 ---
 

--- a/commands/hotfix.md
+++ b/commands/hotfix.md
@@ -1,5 +1,5 @@
 ---
-description: 紧急修复快速通道，跳过 PM/Lead 直接 Dev→Verify→Commit
+description: 緊急修正ファストパス、PM/Lead をスキップし Dev→Verify→Commit を直行
 argument-hint: "[描述]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, Skill
 ---

--- a/commands/infer.md
+++ b/commands/infer.md
@@ -1,5 +1,5 @@
 ---
-description: 模型推理和测试
+description: モデル推論とテスト
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 

--- a/commands/iterate.md
+++ b/commands/iterate.md
@@ -1,5 +1,5 @@
 ---
-description: 自主迭代循环，自动完成任务序列
+description: 自律反復ループ、タスクシーケンスを自動完了
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, WebSearch, WebFetch, Skill, mcp__*
 ---
 

--- a/commands/lead.md
+++ b/commands/lead.md
@@ -1,5 +1,5 @@
 ---
-description: 研发经理智能体，负责技术方案设计和任务分解
+description: 開発リードエージェント、技術設計とタスク分解を担当
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite, Task, Skill, WebSearch, WebFetch, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot
 ---
 

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,5 +1,5 @@
 ---
-description: 会话学习，从会话中提取可复用模式
+description: セッション学習、セッションから再利用可能なパターンを抽出
 argument-hint: "[--status|--export|--import file|--eval]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/memory.md
+++ b/commands/memory.md
@@ -1,5 +1,5 @@
 ---
-description: 项目记忆管理，维护 memory-bank（持久化，另见 /cc-best:context 管理会话上下文）
+description: プロジェクト記憶管理、memory-bank を維持（永続、セッションコンテキストは /cc-best:context）
 argument-hint: "[load|status|sync]"
 allowed-tools: Read, Write, Edit, Glob, Grep
 ---

--- a/commands/mode.md
+++ b/commands/mode.md
@@ -1,5 +1,5 @@
 ---
-description: "切换工作模式以适应不同场景（dev/research/review/planning）"
+description: "作業モード切替（dev/research/review/planning）"
 argument-hint: "[dev|research|review|planning]"
 allowed-tools: Read, Write, Edit, Glob, Grep
 ---

--- a/commands/model.md
+++ b/commands/model.md
@@ -1,5 +1,5 @@
 ---
-description: 切换 Agent 模型策略（质量/均衡/经济）
+description: Agent モデル戦略切替（品質/バランス/経済）
 argument-hint: "[--show]"
 allowed-tools: Read, Bash
 ---

--- a/commands/pair.md
+++ b/commands/pair.md
@@ -1,5 +1,5 @@
 ---
-description: 结对编程模式，与用户协作开发
+description: ペアプログラミングモード、ユーザーと協調開発
 argument-hint: "[--learn]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, WebSearch, WebFetch, Skill, mcp__*
 ---

--- a/commands/pm.md
+++ b/commands/pm.md
@@ -1,5 +1,5 @@
 ---
-description: 产品经理智能体，负责需求分析和产品规划
+description: プロダクトマネージャーエージェント、要件分析と企画を担当
 allowed-tools: Read, Write, Edit, Glob, Grep, TodoWrite, Task, WebSearch, WebFetch, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot
 ---
 

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-description: 创建 Pull Request
+description: Pull Request を作成
 allowed-tools: Read, Glob, Grep, Bash
 ---
 

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -1,5 +1,5 @@
 ---
-description: 测试工程师智能体，负责质量保证和问题验证
+description: QA エンジニアエージェント、品質保証と不具合検証を担当
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite, Task, Skill, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_console_messages, mcp__plugin_playwright_playwright__browser_click, mcp__plugin_playwright_playwright__browser_type, mcp__plugin_playwright_playwright__browser_wait_for
 ---
 

--- a/commands/release.md
+++ b/commands/release.md
@@ -1,5 +1,5 @@
 ---
-description: 版本发布管理（版本号同步、CHANGELOG 更新、Git Tag）
+description: リリース管理（バージョン同期、CHANGELOG 更新、Git Tag）
 argument-hint: "[patch|minor|major] [--dry-run]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/run.md
+++ b/commands/run.md
@@ -1,5 +1,5 @@
 ---
-description: 启动开发服务或应用（快捷启动，完整管理见 /cc-best:service）
+description: 開発サービスやアプリを起動（クイック起動、完全管理は /cc-best:service）
 argument-hint: "[api|frontend|all]"
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/commands/security-audit.md
+++ b/commands/security-audit.md
@@ -1,5 +1,5 @@
 ---
-description: 配置安全扫描，审计插件自身配置的安全性
+description: 設定セキュリティスキャン、プラグイン自身の設定の安全性を監査
 allowed-tools: Read, Glob, Grep, Bash
 ---
 

--- a/commands/self-check.md
+++ b/commands/self-check.md
@@ -1,5 +1,5 @@
 ---
-description: 自我检查，验证输出质量
+description: セルフチェック、出力品質を検証
 allowed-tools: Read, Glob, Grep, Bash, TodoWrite
 ---
 

--- a/commands/service.md
+++ b/commands/service.md
@@ -1,5 +1,5 @@
 ---
-description: 开发服务管理（自动检测运行时、启动/停止/重启服务）
+description: 開発サービス管理（ランタイム自動検出、起動/停止/再起動）
 argument-hint: "[--stop|--restart|--logs] [--port num]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/setup-pm.md
+++ b/commands/setup-pm.md
@@ -1,5 +1,5 @@
 ---
-description: 配置项目首选包管理器 (npm/pnpm/yarn/bun)
+description: プロジェクト優先パッケージマネージャを設定 (npm/pnpm/yarn/bun)
 argument-hint: "[--detect|--project pm|--global pm|--list]"
 allowed-tools: Read, Bash
 ---

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-description: 项目初始化，配置 Claude Code 项目和 Hooks
+description: プロジェクト初期化、Claude Code プロジェクトと Hooks を設定
 argument-hint: "[--hooks|--global|--project] [--verify]"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 ---

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,5 +1,5 @@
 ---
-description: 项目状态与诊断信息
+description: プロジェクト状態と診断情報
 argument-hint: "[--full|--conflicts]"
 allowed-tools: Read, Glob, Grep, Bash
 ---

--- a/commands/stocktake.md
+++ b/commands/stocktake.md
@@ -1,5 +1,5 @@
 ---
-description: 组件库审计，评估 skills/rules/commands 的健康度
+description: コンポーネント監査、skills/rules/commands の健全性を評価
 argument-hint: "[--quick|--full] [--scope skills|rules|commands|all]"
 allowed-tools: Read, Glob, Grep, Bash, TodoWrite, WebSearch
 ---

--- a/commands/task.md
+++ b/commands/task.md
@@ -1,5 +1,5 @@
 ---
-description: 任务粒度管理，分解和追踪任务
+description: タスク粒度管理、タスクの分解と追跡
 allowed-tools: Read, Glob, Grep, Bash, TodoWrite
 ---
 

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,5 +1,5 @@
 ---
-description: 运行项目测试套件
+description: プロジェクトのテストスイートを実行
 allowed-tools: Read, Glob, Grep, Bash
 ---
 

--- a/commands/train.md
+++ b/commands/train.md
@@ -1,5 +1,5 @@
 ---
-description: 训练机器学习/深度学习模型
+description: 機械学習/深層学習モデルの学習
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, TodoWrite
 ---
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,5 +1,5 @@
 ---
-description: 综合验证命令，执行构建、类型、Lint、测试、安全检查
+description: 総合検証コマンド、ビルド・型・Lint・テスト・セキュリティ検査を実行
 allowed-tools: Read, Glob, Grep, Bash, TodoWrite, Task
 ---
 


### PR DESCRIPTION
## Summary
- Translate the frontmatter `description` field of all 44 commands from Chinese to Japanese.
- Affects only the one-line description shown in Claude Code's slash-command autocomplete.
- Command bodies, behavior, and filenames are unchanged.

## Motivation
As a Japanese user of cc-best, the Chinese descriptions in the `/cc-best:` autocomplete menu are hard to scan. This PR provides a Japanese variant.

If upstream prefers Chinese as the canonical language, feel free to close — I'm happy to maintain this as a fork-only patch. Alternatively, a locale-aware structure (e.g. `description.zh` / `description.ja`) would be a longer-term solution.

## Test plan
- [x] All 44 commands' descriptions replaced in place (44 insertions, 44 deletions, one line each)
- [ ] Maintainer confirms Japanese wording reads naturally